### PR TITLE
Fix: Improve media widget stability and appearance

### DIFF
--- a/illustro/Media/Media.ini
+++ b/illustro/Media/Media.ini
@@ -19,7 +19,7 @@ fontSizeTitle=10
 fontSizeInfo=7
 colorText=255,255,255,205
 colorBar=235,170,0,255
-coverDefault=#@#placeholder-square.png
+coverDefault=#@#white.png
 
 coverSize=80
 totalWidth=190
@@ -42,7 +42,7 @@ Substitute="":"UNKNOWN ARTIST"
 Measure=Plugin
 Plugin=WebNowPlaying
 PlayerType=Cover
-Substitute="":"#@#placeholder-square.png"
+Substitute="0":"","":"#@#white.png"
 
 [MeasurePosition]
 Measure=Plugin
@@ -65,7 +65,6 @@ PlayerType=Progress
 Measure=Plugin
 Plugin=WebNowPlaying
 PlayerType=State
-Substitute="0":"1"
 OnChangeAction=[!UpdateMeasure *] [!UpdateMeter *] [!Redraw]
 
 [MeasurePlayPause]
@@ -175,7 +174,7 @@ MeterStyle=styleButton
 ImageName=#@#pause.png
 X=90
 Y=155
-Hidden=([MeasureState]=0)
+Hidden=([MeasureState]<>1)
 LeftMouseUpAction=[!CommandMeasure MeasurePlayPause "PlayPause"]
 DynamicVariables=1
 


### PR DESCRIPTION
This commit addresses follow-up issues with the media widget.

- Fixes a bug where album covers would not appear if the plugin returned "0". The cover measure now correctly handles this case.
- Corrects the play/pause button visibility logic, which was broken in the previous commit. The buttons should now accurately reflect the player's state.
- Replaces the default placeholder image with a cleaner, solid white image for a more minimal appearance.