### PR TITLE
Fix: Rework media widget to correctly use PlayerId

### DIFF
--- a/illustro/Media/Media.ini
+++ b/illustro/Media/Media.ini
@@ -23,6 +23,7 @@ coverDefault=#@#white.png
 
 coverSize=80
 totalWidth=190
+Player=active
 
 ; --- MEASURES ---
 
@@ -30,47 +31,56 @@ totalWidth=190
 Measure=Plugin
 Plugin=WebNowPlaying
 PlayerType=Title
-Substitute="":"NO TITLE"
+PlayerId=#Player#
+Substitute="":"NO TITLE","0":"NO TITLE"
+DynamicVariables=1
 
 [MeasureArtist]
 Measure=Plugin
 Plugin=WebNowPlaying
 PlayerType=Artist
-Substitute="":"UNKNOWN ARTIST"
+PlayerId=#Player#
+Substitute="":"UNKNOWN ARTIST","0":"UNKNOWN ARTIST"
+DynamicVariables=1
 
 [MeasureCover]
 Measure=Plugin
 Plugin=WebNowPlaying
 PlayerType=Cover
-Substitute="0":"","":"#@#white.png"
+PlayerId=#Player#
+DynamicVariables=1
+DefaultPath=#coverDefault#
 
 [MeasurePosition]
 Measure=Plugin
 Plugin=WebNowPlaying
 PlayerType=Position
+PlayerId=#Player#
+DynamicVariables=1
 Substitute="":"0:00"
 
 [MeasureDuration]
 Measure=Plugin
 Plugin=WebNowPlaying
 PlayerType=Duration
+PlayerId=#Player#
+DynamicVariables=1
 Substitute="":"0:00"
 
 [MeasureProgress]
 Measure=Plugin
 Plugin=WebNowPlaying
 PlayerType=Progress
+PlayerId=#Player#
+DynamicVariables=1
 
 [MeasureState]
 Measure=Plugin
 Plugin=WebNowPlaying
 PlayerType=State
+PlayerId=#Player#
+DynamicVariables=1
 OnChangeAction=[!UpdateMeasure *] [!UpdateMeter *] [!Redraw]
-
-[MeasurePlayPause]
-Measure=Plugin
-Plugin=WebNowPlaying
-PlayerType=PlayPause
 
 ; --- STYLES ---
 [styleTitle]
@@ -156,7 +166,7 @@ MeterStyle=styleButton
 ImageName=#@#previous.png
 X=60
 Y=155
-LeftMouseUpAction=[!CommandMeasure MeasurePlayPause "Previous"]
+LeftMouseUpAction=[!CommandMeasure MeasureState "Previous"]
 
 [meterPlay]
 Meter=Image
@@ -165,7 +175,7 @@ ImageName=#@#resume.png
 X=90
 Y=155
 Hidden=([MeasureState]=1)
-LeftMouseUpAction=[!CommandMeasure MeasurePlayPause "PlayPause"]
+LeftMouseUpAction=[!CommandMeasure MeasureState "PlayPause"]
 DynamicVariables=1
 
 [meterPause]
@@ -175,7 +185,7 @@ ImageName=#@#pause.png
 X=90
 Y=155
 Hidden=([MeasureState]<>1)
-LeftMouseUpAction=[!CommandMeasure MeasurePlayPause "PlayPause"]
+LeftMouseUpAction=[!CommandMeasure MeasureState "PlayPause"]
 DynamicVariables=1
 
 [meterNext]
@@ -184,7 +194,7 @@ MeterStyle=styleButton
 ImageName=#@#next.png
 X=120
 Y=155
-LeftMouseUpAction=[!CommandMeasure MeasurePlayPause "Next"]
+LeftMouseUpAction=[!CommandMeasure MeasureState "Next"]
 
 [meterProgressBar]
 Meter=Bar


### PR DESCRIPTION
This commit provides a comprehensive fix for the media widget, addressing all previously reported issues. The root cause was identified as a missing `PlayerId` specification for the WebNowPlaying plugin measures.

- All plugin measures (`Title`, `Artist`, `Cover`, `State`, `Progress`, etc.) have been updated to target the active player using `PlayerId=active`.
- All control buttons (`PlayPause`, `Next`, `Previous`) now correctly send their commands to the `MeasureState` measure, which will now correctly route them to the active player. This fixes the non-functional buttons.
- The album cover measure now uses the recommended `DefaultPath` implementation and the correct `PlayerId`, which should resolve the cover art loading issues.
- The initial text display has been fixed by restoring the substitution for "0" values, preventing "0, 0" from showing when no track is loaded.

The entire skin is now more robust and aligns with the standard implementation for the WebNowPlaying plugin.